### PR TITLE
gitlab_release_notes/generate.py: Add --quiet cmdline option.

### DIFF
--- a/gitlab_release_notes/generate.py
+++ b/gitlab_release_notes/generate.py
@@ -94,7 +94,12 @@ def main():
         endstr = '  <br>'
     else:
         endstr = '\n'
-    notes = generate_release_notes(args.project_id, url=args.url, endstr=endstr, private_token=args.private_token, since=args.since)
+    notes = generate_release_notes(args.project_id,
+                                   url=args.url,
+                                   endstr=endstr,
+                                   since=args.since,
+                                   private_token=args.private_token,
+            )
     print(notes)
 
 if __name__ == "__main__":

--- a/gitlab_release_notes/generate.py
+++ b/gitlab_release_notes/generate.py
@@ -58,7 +58,7 @@ def generate_release_notes(project_id, endstr = '  <br>', since=None, quiet=Fals
     if not list_mrs:
         if not quiet:
             log += log_pending
-            log += f"There is no merged merge request after {last_date}"
+            log += f"There is no merged merge request after {last_date}{endstr}"
         return log
 
     log += log_pending

--- a/gitlab_release_notes/generate.py
+++ b/gitlab_release_notes/generate.py
@@ -1,9 +1,10 @@
+import datetime
 import gitlab
 import os.path
 import sys
 from .version import __version__
 
-def generate_release_notes(project_id, endstr = '  <br>', **config):
+def generate_release_notes(project_id, endstr = '  <br>', since=None, **config):
     """
     Generate the release notes of a gitlab project from the last release
 
@@ -35,7 +36,10 @@ def generate_release_notes(project_id, endstr = '  <br>', **config):
     if not project.mergerequests.list(get_all=False,state='merged'):
         raise ValueError(f"There is no merged merge request for project {project_id} {project.name}")
 
-    if not project.releases.list(get_all=False):
+    if since:
+        log = f"Changelog of {project.name} since {since}:{endstr}"
+        last_date = since
+    elif not project.releases.list(get_all=False):
         log = f"Changelog of {project.name}:{endstr}"
         last_date = '0000-01-01T00:00:00Z'
     else:
@@ -82,6 +86,7 @@ def main():
     parser.add_argument("--private_token", type=str, required=False, default=None)
     parser.add_argument('--version', action='version', version=__version__)
     parser.add_argument('--html', action='store_true')
+    parser.add_argument('--since', type=datetime.date.fromisoformat, required=False, default=None)
 
     args = parser.parse_args()
 
@@ -89,7 +94,7 @@ def main():
         endstr = '  <br>'
     else:
         endstr = '\n'
-    notes = generate_release_notes(args.project_id, url=args.url, endstr=endstr, private_token=args.private_token)
+    notes = generate_release_notes(args.project_id, url=args.url, endstr=endstr, private_token=args.private_token, since=args.since)
     print(notes)
 
 if __name__ == "__main__":

--- a/gitlab_release_notes/generate.py
+++ b/gitlab_release_notes/generate.py
@@ -33,7 +33,7 @@ def generate_release_notes(project_id, endstr = '  <br>', **config):
     project = gl.projects.get(project_id)
 
     if not project.mergerequests.list(get_all=False,state='merged'):
-        raise ValueError(f"There is not merged merge request for project {project_id} {project.name}")
+        raise ValueError(f"There is no merged merge request for project {project_id} {project.name}")
 
     if not project.releases.list(get_all=False):
         log = f"Changelog of {project.name}:{endstr}"

--- a/gitlab_release_notes/generate.py
+++ b/gitlab_release_notes/generate.py
@@ -32,19 +32,20 @@ def generate_release_notes(project_id, endstr = '  <br>', **config):
     gl = gitlab.Gitlab(**config)
     project = gl.projects.get(project_id)
 
-    if not project.mergerequests.list(state='merged'):
+    if not project.mergerequests.list(get_all=False,state='merged'):
         raise ValueError(f"There is not merged merge request for project {project_id} {project.name}")
 
-    if not project.releases.list():
+    if not project.releases.list(get_all=False):
         log = f"Changelog of {project.name}:{endstr}"
         last_date = '0000-01-01T00:00:00Z'
     else:
-        last_release = project.releases.list()[0]
+        last_release = project.releases.list(get_all=False)[0]
         log = f"Changelog since release {last_release.name} of {project.name}:{endstr}"
         last_date = last_release.released_at
 
     page = 1
     list_mrs = project.mergerequests.list(state='merged',
+                                          get_all=False,
                                           order_by='updated_at',
                                           updated_after=last_date,
                                           page=page)
@@ -59,6 +60,7 @@ def generate_release_notes(project_id, endstr = '  <br>', **config):
 
         page += 1
         list_mrs = project.mergerequests.list(state='merged',
+                                              get_all=False,
                                               order_by='updated_at',
                                               updated_after=last_date,
                                               page=page

--- a/gitlab_release_notes/generate.py
+++ b/gitlab_release_notes/generate.py
@@ -107,7 +107,8 @@ def main():
                                    quiet=args.quiet,
                                    private_token=args.private_token,
             )
-    print(notes)
+    if notes:
+        print(notes)
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
This shall hide any output if repositories haven't seen any MRs since the last release (or the given date specified via --since).

This PR depends on #4 (as it contains changes near those changes).