### PR TITLE
gitlab_release_notes/generate.py: also take merged_at into consideration 

### DIFF
--- a/gitlab_release_notes/generate.py
+++ b/gitlab_release_notes/generate.py
@@ -59,7 +59,7 @@ def generate_release_notes(project_id, endstr = '  <br>', since=None, quiet=Fals
     page = 1
     list_mrs = project.mergerequests.list(state='merged',
                                           get_all=False,
-                                          order_by='updated_at',
+                                          order_by='merged_at',
                                           updated_after=last_date,
                                           page=page)
     if not list_mrs:

--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,7 @@ setup(
     long_description_content_type="text/markdown",
     author="vuillaut",
     packages=find_packages(exclude=["gitlab_release_notes/tests", ".github"]),
-    install_requires=['python-gitlab>=3.0'],
+    install_requires=['python-gitlab>=3.0', 'python-dateutil'],
     entry_points={
         "console_scripts": ["gitlab-release-notes = gitlab_release_notes.generate:main"]
     },


### PR DESCRIPTION
`updated_at` could be after `merged_at`, e.g. for MRs that has
additional comments after it's merged. So, after filtering by
`updated_after` parameter, also do client-side filtering on `merged_at`
field.

Now, an interesting thing is that while GitLab offers
order_by='merged_at' (since GitLab 17.2 [1]), there's no `merged_after`
parameter that we can use. So we can't tell server to filter this for
us.

Also, Python cannot parse GitLab's spec-complient ISO8601 datetime until
3.11 [2]. Thus a library called `dateutil` is added as an external
dependency.

[1]\: https://gitlab.com/gitlab-org/gitlab/-/merge_requests/147052
[2]\: https://docs.python.org/3/whatsnew/3.11.html#datetime